### PR TITLE
DCK-29: Fix weight for logout link in user menu

### DIFF
--- a/docroot/modules/custom/dckyiv_user/dckyiv_user.links.task.yml
+++ b/docroot/modules/custom/dckyiv_user/dckyiv_user.links.task.yml
@@ -2,3 +2,4 @@ dckyiv_user.logout_link:
   route_name: user.logout
   base_route: entity.user.canonical
   title: 'Log out'
+  weight: 300


### PR DESCRIPTION
## Issue

> **Move logout link to the end of user menu**

## Steps for review:

- [ ] login as a simple user (visitor).
- [ ] verify the Logout link at the end of the user menu.

## General checks
- [ ] All coding styles are fulfilled and there are no any issues reported by CodeSniffer.
- [ ] All tests are running and there are no failed tests reported by CI.
- [ ] Documentation has been updated according to PR changes.
- [ ] Steps for review have been provided according to PR changes.

Thank you for your сontribution and help to Drupal Ukraine!
